### PR TITLE
Update docker-compose-example.yml

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -1,3 +1,5 @@
+version: '3.4'
+
 x-common-variables: &feedbin-environment
 - PORT
 - RACK_ENV


### PR DESCRIPTION
fixes service 'x-common-variables' must be a mapping not an array.